### PR TITLE
Support miscellaneous attributes

### DIFF
--- a/lib/seory/dsl.rb
+++ b/lib/seory/dsl.rb
@@ -25,10 +25,12 @@ module Seory
         @page_contents
       end
 
+      def misc(name, val = nil, &block)
+        @page_contents.define(name, val, &block)
+      end
+
       Seory::CONTENTS.each do |name|
-        define_method(name) do |val = nil, &block|
-          @page_contents.define(name, val, &block)
-        end
+        define_method(name) {|val = nil, &block| misc(name, val, &block) }
       end
     end
 

--- a/lib/seory/runtime.rb
+++ b/lib/seory/runtime.rb
@@ -12,8 +12,12 @@ module Seory
       @controller    = controller
     end
 
+    def misc(name)
+      calculate_content_for(name)
+    end
+
     Seory::CONTENTS.each do |name|
-      define_method(name) { calculate_content_for(name) }
+      define_method(name) { misc(name) }
     end
 
     private

--- a/spec/seory/dsl_spec.rb
+++ b/spec/seory/dsl_spec.rb
@@ -8,11 +8,15 @@ describe Seory::Dsl do
       match 'products#index' do
         title 'My Great Product'
         h1    'Great Product Name'
+
+        misc :option, 'static optional val'
       end
 
       default do
         title 'Misc site'
         h1    { controller.controller_name.upcase }
+
+        misc(:option) { "dynamic option name at #{controller.controller_name}" }
       end
     end
   end
@@ -24,11 +28,13 @@ describe Seory::Dsl do
 
     specify { expect(seory.title).to eq 'My Great Product' }
     specify { expect(seory.h1).to eq 'Great Product Name' }
+    specify { expect(seory.misc(:option)).to eq 'static optional val' }
   end
 
   context 'at misc#show' do
     let(:controller) { double('controller', controller_name: 'misc', action_name: 'show') }
 
     specify { expect(seory.h1).to eq 'MISC' }
+    specify { expect(seory.misc(:option)).to eq 'dynamic option name at misc' }
   end
 end


### PR DESCRIPTION
seory supports `title h1 h2 meta_description meta_keywords canonical_url image_url` attributes(see `Seory::CONTENTS`). But sometimes we want other attributes based on page context.

So it's better to define/read misc attributes.
