### PR TITLE
Enable hash conditions

### DIFF
--- a/lib/seory/page_contents.rb
+++ b/lib/seory/page_contents.rb
@@ -26,7 +26,14 @@ module Seory
       if @conditions.respond_to?(:call)
         @conditions.call(controller)
       else
-        @conditions.include?(action_slug(controller))
+        @conditions.any? do |condition|
+          case condition
+          when Hash
+            controller.params.slice(*condition.keys).symbolize_keys == condition
+          else
+            action_slug(controller) == condition
+          end
+        end
       end
     end
 

--- a/spec/seory/page_contents_spec.rb
+++ b/spec/seory/page_contents_spec.rb
@@ -68,5 +68,36 @@ describe Seory::PageContents do
         expect(page_contents.match?(controller)).to be_truthy
       end
     end
+
+    describe 'hash conditions' do
+      let(:controller) { double('controller', params: params.with_indifferent_access) }
+
+      context 'when the condition exactly equals the params' do
+        let(:params) { { "controller" => 'users', "action" => 'show' } }
+        let(:condition) { { controller: 'users', action: 'show' } }
+
+        specify do
+          expect(init_with(condition).match?(controller)).to be_truthy
+        end
+      end
+
+      context 'when the condition is a sub-hash of the params' do
+        let(:params) { { "controller" => 'users', "action" => 'show', "id" => "123" } }
+        let(:condition) { { controller: 'users', action: 'show' } }
+
+        specify do
+          expect(init_with(condition).match?(controller)).to be_truthy
+        end
+      end
+
+      context 'when the condition differs with the params' do
+        let(:params) { { "controller" => 'users', "action" => 'show' } }
+        let(:condition) { { controller: 'users', action: 'index' } }
+
+        specify do
+          expect(init_with(condition).match?(controller)).to be_falsy
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
条件をハッシュで書けるようにしました。たとえばこんな感じで使えるようにします。

``` ruby
# /users/foo のときだけ一致
match controller: 'users', action: 'show', permalink: 'foo' do
  # ...
end
```
