### PR TITLE
Include Seory::RailsHelper in Railtie

### DIFF
--- a/lib/seory/railtie.rb
+++ b/lib/seory/railtie.rb
@@ -6,6 +6,10 @@ module Seory
       config_dir = (Rails.root + Seory.config_dir)
 
       app.config.to_prepare { config_dir.each_child {|src| src.extname == '.rb' && load(src) } }
+
+      ActiveSupport.on_load :action_view do
+        include Seory::RailsHelper
+      end
     end
   end
 end


### PR DESCRIPTION
To use seory, we would need to include `Seory::RailsHelper` in the application.
In this PR, seory loads it with `ActiveSupport.on_load` in railtie.rb.