### PR TITLE
Drop support for Ruby 2.5 and earlier versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
+  - 2.6.6
+  - 2.7.2
+  - ruby-head
+
+jobs:
+  allow_failures:
+    - rvm: ruby-head
+
 env:
   - secure: "d3P4g1NRNxoCuhCHaqpNI6Khe6d/5jYpR0VJoxAvw5n2c46KuMn91IMTmTAF73vb7n8kQAXA347x53KBdgsBlmm6upaBKG8NrWiLgO16frTlmtUf1ng6VZzM3vqQjjo1YZLhM+kk3AoXgqZsSMwfgOo9BFQj6fYRwlveuJ+vrVM="
 notifications:
   webhooks:
     - https://idobata.io/hook/061179f9-4f3c-4c8c-bdf9-4efa9821c5c5
-

--- a/seory.gemspec
+++ b/seory.gemspec
@@ -4,23 +4,24 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'seory/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "seory"
-  spec.version       = Seory::VERSION
-  spec.authors       = ["moro"]
-  spec.email         = ["moronatural@gmail.com"]
-  spec.summary       = %q{SEO contents manager for Rails.}
-  spec.description   = %q{Manage SEO contets in Rails app. based on controller, action and more complex context.}
-  spec.homepage      = "https://github.com/esminc/seory"
-  spec.license       = "MIT"
+  spec.name                  = "seory"
+  spec.version               = Seory::VERSION
+  spec.authors               = ["moro"]
+  spec.email                 = ["moronatural@gmail.com"]
+  spec.summary               = %q{SEO contents manager for Rails.}
+  spec.description           = %q{Manage SEO contets in Rails app. based on controller, action and more complex context.}
+  spec.homepage              = "https://github.com/esminc/seory"
+  spec.license               = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.files                 = `git ls-files -z`.split("\x0")
+  spec.executables           = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files            = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths         = ["lib"]
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "activesupport", "> 3.2"
   spec.add_dependency "railties",      "> 3.2"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
I would like to let Seory work with later Ruby versions.