### PR TITLE
Update rails dependencies

### DIFF
--- a/seory.gemspec
+++ b/seory.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ["lib"]
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_dependency "activesupport", "> 3.2"
-  spec.add_dependency "railties",      "> 3.2"
+  spec.add_dependency "activesupport", "> 5.2"
+  spec.add_dependency "railties",      "> 5.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Updated rails dependencies. 

Since there is an issue about `BigDecimal.new` compatibility between Ruby 2.6 (or later) and activesupport 4.2, we use activesupport 5.2 or later.